### PR TITLE
Allow multiple instances on Mac

### DIFF
--- a/ember-electron/main.js
+++ b/ember-electron/main.js
@@ -99,6 +99,9 @@ function setupListeners() {
 }
 
 app.on('window-all-closed', () => {
+    serverInstance.stop();
+    serverInstance = null;
+
     if (process.platform !== 'darwin') {
         // Using exit instead of quit for the time being
         // see: https://github.com/electron/electron/issues/8862#issuecomment-294303518

--- a/ember-electron/main.js
+++ b/ember-electron/main.js
@@ -109,15 +109,6 @@ app.on('window-all-closed', () => {
     }
 });
 
-app.on('before-quit', () => {
-    if (window && !window.isDestroyed() && window.isVisible()) {
-        window.removeAllListeners();
-        window.close();
-
-        setTimeout(() => app.exit(), 2000);
-    }
-});
-
 app.on('ready', () => {
     createServer();
 });

--- a/ember-electron/main.js
+++ b/ember-electron/main.js
@@ -128,7 +128,7 @@ app.on('activate', () => {
     if (serverInstance === null) {
         createServer();
     } else if (mainWindow === null) {
-        createWindow(serverPort);
+        createWindow();
     }
 });
 

--- a/ember-electron/main.js
+++ b/ember-electron/main.js
@@ -50,8 +50,10 @@ function createServer() {
     serverInstance = backendServer(absPath)
     serverInstance.start((serverPort) => {
         global.serverPort = serverPort;
-        createWindow();
-        setupListeners();
+
+        if (mainWindow === null) {
+            createWindow();
+        }
     });
 }
 
@@ -67,6 +69,8 @@ function createWindow() {
 
     // Load the ember application using our custom protocol/scheme
     mainWindow.loadURL(APP_URL);
+
+    setupListeners();
 }
 
 function setupListeners() {


### PR DESCRIPTION
A couple of improvements on Mac OS:

* Allow running multiple instances
* Ensure the app terminates the API server when you close it via X button (or CMD+W) and starts again when you open it from Dock