### PR TITLE
Support different output formats for I/O streams and Syscalls

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -60,7 +60,7 @@ export default Ember.Route.extend({
 
                 shortcuts.defineShortcut('data.viewAsPrintableAscii',   'data',         'View as printable ASCII',  ['v+a']),
                 shortcuts.defineShortcut('data.viewAsDottedAscii',      'data',         'View as dotted ASCII',     ['v+d']),
-                shortcuts.defineShortcut('data.viewAsHex',              'data',         'View as hex',              ['v+x']),
+                shortcuts.defineShortcut('data.viewAsHexAscii',         'data',         'View as hex',              ['v+x']),
 
                 shortcuts.defineShortcut('overview.drillDown',          'overview',     'Drill down',               ['enter']),
                 shortcuts.defineShortcut('overview.toggleTimeline',     'overview',     'Pin/unpin timeline',       ['space']),

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -58,6 +58,10 @@ export default Ember.Route.extend({
                 shortcuts.defineShortcut('dataTables.selectNext',       'dataTables',   'Select next row',          ['down']),
                 shortcuts.defineShortcut('dataTables.selectPrevious',   'dataTables',   'Select previous row',      ['up']),
 
+                shortcuts.defineShortcut('data.viewAsPrintableAscii',   'data',         'View as printable ASCII',  ['v+a']),
+                shortcuts.defineShortcut('data.viewAsDottedAscii',      'data',         'View as dotted ASCII',     ['v+d']),
+                shortcuts.defineShortcut('data.viewAsHex',              'data',         'View as hex',              ['v+x']),
+
                 shortcuts.defineShortcut('overview.drillDown',          'overview',     'Drill down',               ['enter']),
                 shortcuts.defineShortcut('overview.toggleTimeline',     'overview',     'Pin/unpin timeline',       ['space']),
                 shortcuts.defineShortcut('overview.selectLeft',         'overview',     'Select left',              ['left']),

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -58,9 +58,9 @@ export default Ember.Route.extend({
                 shortcuts.defineShortcut('dataTables.selectNext',       'dataTables',   'Select next row',          ['down']),
                 shortcuts.defineShortcut('dataTables.selectPrevious',   'dataTables',   'Select previous row',      ['up']),
 
-                shortcuts.defineShortcut('data.viewAsPrintableAscii',   'data',         'View as printable ASCII',  ['v+a']),
-                shortcuts.defineShortcut('data.viewAsDottedAscii',      'data',         'View as dotted ASCII',     ['v+d']),
-                shortcuts.defineShortcut('data.viewAsHexAscii',         'data',         'View as hex',              ['v+x']),
+                shortcuts.defineShortcut('data.viewAsPrintableAscii',   'data',         'View as printable ASCII',  ['v a']),
+                shortcuts.defineShortcut('data.viewAsDottedAscii',      'data',         'View as dotted ASCII',     ['v d']),
+                shortcuts.defineShortcut('data.viewAsHexAscii',         'data',         'View as hex',              ['v x']),
 
                 shortcuts.defineShortcut('overview.drillDown',          'overview',     'Drill down',               ['enter']),
                 shortcuts.defineShortcut('overview.toggleTimeline',     'overview',     'Pin/unpin timeline',       ['space']),

--- a/ember-electron/backend/server.js
+++ b/ember-electron/backend/server.js
@@ -109,7 +109,7 @@ class Server {
             case 'dottedAscii':
                 // no argument needed
                 break;
-            case 'hex':
+            case 'Hex':
                 args.push('-X');
                 break;
             default:

--- a/ember-electron/backend/server.js
+++ b/ember-electron/backend/server.js
@@ -105,24 +105,17 @@ class Server {
         let viewInfo = JSON.parse(request.params.view);
         let args = ['-r', fileName, '-v', viewInfo.id, '-j', '-pc'];
 
-        if ('from' in request.query) {
-            args.push('--from');
-            args.push(request.query.from);
-        }
-
-        if ('to' in request.query) {
-            args.push('--to');
-            args.push(request.query.to);
-        }
-
-        if ('viewAs' in request.query) {
-            if (request.query.viewAs === 'Hex') {
+        switch (viewInfo.viewAs) {
+            case 'dottedAscii':
+                // no argument needed
+                break;
+            case 'hex':
                 args.push('-X');
-            } else if (request.query.viewAs !== 'dottedAscii') {
+                break;
+            default:
+                // default to printable ASCII
                 args.push('-A');
-            }
-        } else {
-            args.push('-A');
+                break;
         }
 
         if ('filter' in viewInfo) {

--- a/lib/ui-toolkit/addon/components/sd-button.js
+++ b/lib/ui-toolkit/addon/components/sd-button.js
@@ -28,7 +28,6 @@ export default Ember.Component.extend({
         'isLight:sd-button--is-light',
         'isPrimary:sd-button--is-primary',
         'isActive:sd-button--is-active',
-        'isSelected:sd-button--is-selected'
     ],
     attributeBindings: ['tabIndex', 'title', 'isDisabled:disabled'],
 
@@ -38,7 +37,6 @@ export default Ember.Component.extend({
     color: null,
     isActive: false,
     isDisabled: false,
-    isSelected: false,
 
     isSm: Ember.computed.equal('size', 'sm').readOnly(),
     isLg: Ember.computed.equal('size', 'lg').readOnly(),

--- a/lib/ui-toolkit/addon/components/sd-button.js
+++ b/lib/ui-toolkit/addon/components/sd-button.js
@@ -27,7 +27,7 @@ export default Ember.Component.extend({
         'isWhite:sd-button--is-white',
         'isLight:sd-button--is-light',
         'isPrimary:sd-button--is-primary',
-        'isActive:sd-button--is-active',
+        'isActive:sd-button--is-active'
     ],
     attributeBindings: ['tabIndex', 'title', 'isDisabled:disabled'],
 

--- a/lib/ui-toolkit/addon/styles/sd-button.less
+++ b/lib/ui-toolkit/addon/styles/sd-button.less
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     position: relative;
     min-width: @layout-size-md * 2;
     height: @layout-size-md;
@@ -37,6 +38,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     font-weight: @font-weight-regular;
     letter-spacing: .04em;
     line-height: @layout-size-md;
+    text-align: center;
     text-decoration: none;
     text-transform: uppercase;
     overflow: hidden;
@@ -70,6 +72,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         }
     }
 
+    &--is-active,
+    &--is-white&--is-active {
+        background-color: @color-list-item-selected;
+
+        &:hover,
+        &:focus {
+            background-color: @color-list-item-selected-hover;
+        }
+    }
+
     &--is-primary {
         background-color: @color-primary;
         color: white;
@@ -95,14 +107,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             background-color: darken(white, 1%);
         }
     }
-    &--is-white&--is-selected {
-        background-color: @color-list-item-selected;
-
-        &:hover,
-        &:focus {
-            background-color: @color-list-item-selected-hover;
-        }
-    }
 
     &--is-light {
         color: white;
@@ -119,18 +123,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         }
     }
 
-    &--is-active {
-        background-color: @color-primary;
-
-        opacity: 1;
-
-        svg {
-            fill: white;
-        }
-
-        &:hover {
-            background-color: darken(@color-primary, 5%);
-        }
+    &--no-text-transform {
+        text-transform: none;
     }
 
     &--sm {
@@ -177,6 +171,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         min-width: @layout-size-md;
 
         border-radius: 50%;
+    }
+
+    &--fab&--is-active {
+        background-color: @color-primary;
+
+        opacity: 1;
+
+        svg {
+            fill: white;
+        }
+
+        &:hover {
+            background-color: darken(@color-primary, 5%);
+        }
     }
     &--sm&--fab {
         padding: round(@layout-size-sm - @icon-size-sm) / 2;

--- a/lib/wsd-core/addon/components/wsd-capture-view.js
+++ b/lib/wsd-core/addon/components/wsd-capture-view.js
@@ -122,6 +122,10 @@ export default Ember.Component.extend({
                 this.setViewAs(dataStoreConstants.VIEW_AS_HEX_ASCII);
             }
         );
+
+        this.get('layoutProvider').whenSettled(() => {
+            this.focusMainComponent();
+        });
     },
 
     willDestroyElement() {
@@ -130,12 +134,6 @@ export default Ember.Component.extend({
         this.get('shortcutsService').unbind('data.viewAsHexAscii');
 
         this.get('dataSearchService').off('didChangeSelection', this, this.didChangeSelection);
-    },
-
-    didInsertElement() {
-        this.get('layoutProvider').whenSettled(() => {
-            this.focusMainComponent();
-        });
     },
 
     didUpdateAttrs() {

--- a/lib/wsd-core/addon/components/wsd-capture-view.js
+++ b/lib/wsd-core/addon/components/wsd-capture-view.js
@@ -36,7 +36,7 @@ export default Ember.Component.extend({
     timelines: null,
 
     dataStoreConstants,
-    viewAs: dataStoreConstants.VIEW_AS_PRINTABLE_ASCII,
+    viewAs: dataStoreConstants.VIEW_AS_DOTTED_ASCII,
 
     dataStore: null,
 

--- a/lib/wsd-core/addon/components/wsd-capture-view.js
+++ b/lib/wsd-core/addon/components/wsd-capture-view.js
@@ -107,9 +107,9 @@ export default Ember.Component.extend({
             }
         );
         this.get('shortcutsService').bind(
-            'data.viewAsHex',
+            'data.viewAsHexAscii',
             () => {
-                this.setViewAs(dataStoreConstants.VIEW_AS_HEX);
+                this.setViewAs(dataStoreConstants.VIEW_AS_HEX_ASCII);
             }
         );
     },
@@ -117,7 +117,7 @@ export default Ember.Component.extend({
     willDestroyElement() {
         this.get('shortcutsService').unbind('data.viewAsPrintableAscii');
         this.get('shortcutsService').unbind('data.viewAsDottedAscii');
-        this.get('shortcutsService').unbind('data.viewAsHex');
+        this.get('shortcutsService').unbind('data.viewAsHexAscii');
 
         this.get('dataSearchService').off('didChangeSelection', this, this.didChangeSelection);
     },
@@ -141,7 +141,7 @@ export default Ember.Component.extend({
                 {
                     timeWindow: this.get('timeWindow'),
                     filter: this.get('currentFilter'),
-                    viewAs: this.get('isViewAsSupported') ? (this.get('viewAs') || dataStoreConstants.VIEW_AS_PRINTABLE_ASCII) : null,
+                    viewAs: this.get('isViewAsSupported') ? (this.get('viewAs') || dataStoreConstants.VIEW_AS_DOTTED_ASCII) : null,
                 }
             );
 

--- a/lib/wsd-core/addon/components/wsd-capture-view.js
+++ b/lib/wsd-core/addon/components/wsd-capture-view.js
@@ -16,6 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import Ember from 'ember';
 import layout from '../templates/components/wsd-capture-view';
+import { dataStoreConstants } from '../services/fetch-view-data';
 
 export default Ember.Component.extend({
     layout,
@@ -25,12 +26,15 @@ export default Ember.Component.extend({
     dataSearchService: Ember.inject.service('data-search'),
     viewDataStoreService: Ember.inject.service('fetch-views'),
     layoutProvider: Ember.inject.service('layout-provider'),
+    shortcutsService: Ember.inject.service('keyboard-shortcuts'),
 
     viewId: null,
     captureInfo: null,
     drilldownInfoParam: null,
     filter: null,
     timelines: null,
+
+    viewAs: null,
 
     dataStore: null,
 
@@ -89,12 +93,44 @@ export default Ember.Component.extend({
         this.fetchData();
     },
 
+    didInsertElement() {
+        this.get('shortcutsService').bind(
+            'data.viewAsPrintableAscii',
+            () => {
+                this.setViewAs(dataStoreConstants.VIEW_AS_PRINTABLE_ASCII);
+            }
+        );
+        this.get('shortcutsService').bind(
+            'data.viewAsDottedAscii',
+            () => {
+                this.setViewAs(dataStoreConstants.VIEW_AS_DOTTED_ASCII);
+            }
+        );
+        this.get('shortcutsService').bind(
+            'data.viewAsHex',
+            () => {
+                this.setViewAs(dataStoreConstants.VIEW_AS_HEX);
+            }
+        );
+    },
+
     willDestroyElement() {
+        this.get('shortcutsService').unbind('data.viewAsPrintableAscii');
+        this.get('shortcutsService').unbind('data.viewAsDottedAscii');
+        this.get('shortcutsService').unbind('data.viewAsHex');
+
         this.get('dataSearchService').off('didChangeSelection', this, this.didChangeSelection);
     },
 
     didUpdateAttrs() {
         Ember.run.once(this, this.fetchData);
+    },
+
+    setViewAs(viewAs) {
+        if (this.get('isViewAsSupported') && this.get('viewAs') !== viewAs) {
+            this.set('viewAs', viewAs);
+            Ember.run.once(this, this.fetchData);
+        }
     },
 
     fetchData() {
@@ -105,6 +141,7 @@ export default Ember.Component.extend({
                 {
                     timeWindow: this.get('timeWindow'),
                     filter: this.get('currentFilter'),
+                    viewAs: this.get('isViewAsSupported') ? (this.get('viewAs') || dataStoreConstants.VIEW_AS_PRINTABLE_ASCII) : null,
                 }
             );
 
@@ -135,6 +172,16 @@ export default Ember.Component.extend({
             el.focus();
         }
     },
+
+    isViewAsSupported: Ember.computed('viewId', function() {
+        switch (this.get('viewId')) {
+            case 'dig':
+            case 'echo':
+                return true;
+            default:
+                return false;
+        }
+    }).readOnly(),
 
     actions: {
         select(row) {

--- a/lib/wsd-core/addon/components/wsd-capture-view.js
+++ b/lib/wsd-core/addon/components/wsd-capture-view.js
@@ -27,6 +27,7 @@ export default Ember.Component.extend({
     viewDataStoreService: Ember.inject.service('fetch-views'),
     layoutProvider: Ember.inject.service('layout-provider'),
     shortcutsService: Ember.inject.service('keyboard-shortcuts'),
+    userTracking: Ember.inject.service('user-tracking'),
 
     viewId: null,
     captureInfo: null,
@@ -34,7 +35,8 @@ export default Ember.Component.extend({
     filter: null,
     timelines: null,
 
-    viewAs: null,
+    dataStoreConstants,
+    viewAs: dataStoreConstants.VIEW_AS_PRINTABLE_ASCII,
 
     dataStore: null,
 
@@ -93,6 +95,10 @@ export default Ember.Component.extend({
         this.fetchData();
     },
 
+    isViewAsPrintableAscii: Ember.computed.equal('viewAs', dataStoreConstants.VIEW_AS_PRINTABLE_ASCII).readOnly(),
+    isViewAsDottedAscii: Ember.computed.equal('viewAs', dataStoreConstants.VIEW_AS_DOTTED_ASCII).readOnly(),
+    isViewAsHexAscii: Ember.computed.equal('viewAs', dataStoreConstants.VIEW_AS_HEX_ASCII).readOnly(),
+
     didInsertElement() {
         this.get('shortcutsService').bind(
             'data.viewAsPrintableAscii',
@@ -128,6 +134,11 @@ export default Ember.Component.extend({
 
     setViewAs(viewAs) {
         if (this.get('isViewAsSupported') && this.get('viewAs') !== viewAs) {
+            this.get('userTracking').action(this.get('userTracking').ACTIONS.INTERACTION, {
+                name: 'change view as',
+                'view as': viewAs.toLowerCase().replace(/_/g, ' '),
+            });
+
             this.set('viewAs', viewAs);
             Ember.run.once(this, this.fetchData);
         }
@@ -224,6 +235,10 @@ export default Ember.Component.extend({
             );
 
             this.sendAction('drillDown', this.get('drilldownManager').convertToUrl(nextDrilldownInfo));
+        },
+
+        setViewAs(viewAs) {
+            this.setViewAs(viewAs);
         },
     },
 });

--- a/lib/wsd-core/addon/services/fetch-view-data.js
+++ b/lib/wsd-core/addon/services/fetch-view-data.js
@@ -79,7 +79,7 @@ export default Ember.Service.extend({
 export const dataStoreConstants = {
     VIEW_AS_PRINTABLE_ASCII: 'VIEW_AS_PRINTABLE_ASCII',
     VIEW_AS_DOTTED_ASCII: 'VIEW_AS_DOTTED_ASCII',
-    VIEW_AS_HEX: 'VIEW_AS_HEX',
+    VIEW_AS_HEX_ASCII: 'VIEW_AS_HEX_ASCII',
 };
 
 function getCacheId() {
@@ -88,7 +88,7 @@ function getCacheId() {
 
 function serializeViewAs(viewAs) {
     switch (viewAs) {
-        case dataStoreConstants.VIEW_AS_HEX:
+        case dataStoreConstants.VIEW_AS_HEX_ASCII:
             return 'hex';
         case dataStoreConstants.VIEW_AS_DOTTED_ASCII:
             return 'dottedAscii';

--- a/lib/wsd-core/addon/services/fetch-view-data.js
+++ b/lib/wsd-core/addon/services/fetch-view-data.js
@@ -44,6 +44,9 @@ export default Ember.Service.extend({
             if (Ember.isNone(options.sortingColumn) === false) {
                 urlParams.sortingCol = options.sortingColumn;
             }
+            if (Ember.isNone(options.viewAs) === false) {
+                urlParams.viewAs = serializeViewAs(options.viewAs);
+            }
 
             let url = this.get('apiServerAdapter').buildURL(this.get('request').getURL('view', filePath, urlParams));
 
@@ -73,8 +76,25 @@ export default Ember.Service.extend({
     },
 });
 
+export const dataStoreConstants = {
+    VIEW_AS_PRINTABLE_ASCII: 'VIEW_AS_PRINTABLE_ASCII',
+    VIEW_AS_DOTTED_ASCII: 'VIEW_AS_DOTTED_ASCII',
+    VIEW_AS_HEX: 'VIEW_AS_HEX',
+};
+
 function getCacheId() {
     return JSON.stringify(arguments);
+}
+
+function serializeViewAs(viewAs) {
+    switch (viewAs) {
+        case dataStoreConstants.VIEW_AS_HEX:
+            return 'hex';
+        case dataStoreConstants.VIEW_AS_DOTTED_ASCII:
+            return 'dottedAscii';
+        default:
+            return 'printableAscii';
+    }
 }
 
 function loadData({ resolve, reject, promiseState, cacheId, onStartCallback, url, slowItDown }) {

--- a/lib/wsd-core/addon/services/fetch-view-data.js
+++ b/lib/wsd-core/addon/services/fetch-view-data.js
@@ -89,7 +89,7 @@ function getCacheId() {
 function serializeViewAs(viewAs) {
     switch (viewAs) {
         case dataStoreConstants.VIEW_AS_HEX_ASCII:
-            return 'hex';
+            return 'Hex';
         case dataStoreConstants.VIEW_AS_DOTTED_ASCII:
             return 'dottedAscii';
         default:

--- a/lib/wsd-core/addon/styles/wsd-capture-data-dig.less
+++ b/lib/wsd-core/addon/styles/wsd-capture-data-dig.less
@@ -21,6 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     align-items: stretch;
     overflow: hidden;
 
+    background-color: @color-background-data;
+
     &__content {
         flex: 1;
 

--- a/lib/wsd-core/addon/styles/wsd-capture-data-echo.less
+++ b/lib/wsd-core/addon/styles/wsd-capture-data-echo.less
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     display: flex;
     flex-direction: column;
+    background-color: @color-background-data;
 
     &__content {
         overflow: auto;

--- a/lib/wsd-core/addon/styles/wsd-capture-view.less
+++ b/lib/wsd-core/addon/styles/wsd-capture-view.less
@@ -40,7 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         padding: @layout-padding-sm @layout-padding-md;
 
         background-color: @color-background-panel;
-        border-top: 1px solid @color-separator;
+        border-bottom: 1px solid @color-separator;
     }
     &__settings-bar-label {
         margin-right: @layout-spacing-md;

--- a/lib/wsd-core/addon/styles/wsd-capture-view.less
+++ b/lib/wsd-core/addon/styles/wsd-capture-view.less
@@ -30,4 +30,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         display: flex;
         align-items: stretch;
     }
+
+    &__settings-bar {
+        display: flex;
+
+        padding: @layout-padding-sm @layout-padding-md;
+
+        background-color: @color-background-panel;
+        border-top: 1px solid @color-separator;
+    }
+    &__settings-bar-label {
+        margin-right: @layout-spacing-md;
+
+        display: flex;
+        align-items: center;
+    }
+    &__settings-bar-control + &__settings-bar-control {
+        margin-left: @layout-spacing-sm;
+    }
 }

--- a/lib/wsd-core/addon/templates/components/wsd-capture-data-dig.hbs
+++ b/lib/wsd-core/addon/templates/components/wsd-capture-data-dig.hbs
@@ -16,8 +16,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <div class="wsd-capture-data-dig__content" tabIndex="0">
     {{#each rows key="@index" as |row|}}
-        <div class="wsd-capture-data-dig__row {{if row.isNotSearchMatch "wsd-capture-data-dig__row--is-not-search-match"}}">
-            {{sd-tokenized-output output=row.data}}
-        </div>
+        <div class="wsd-capture-data-dig__row {{if row.isNotSearchMatch "wsd-capture-data-dig__row--is-not-search-match"}}">{{sd-tokenized-output output=row.data isPre=true}}</div>
     {{/each}}
 </div>

--- a/lib/wsd-core/addon/templates/components/wsd-capture-view.hbs
+++ b/lib/wsd-core/addon/templates/components/wsd-capture-view.hbs
@@ -14,28 +14,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --}}
 
-{{#if isOverview}}
-    {{wsd-capture-overview
-        filePath=captureInfo.filePath
-        timelines=metricTimelines
-        timeWindow=timeWindow
-        drilldownInfoParam=model.queryParams.drilldownInfoParam
-        toggleMetricTimeline=(action toggleMetricTimeline)
-        drillDown=(action drillDown)
-    }}
-{{else}}
-    <div class="wsd-capture-view__content">
-        {{component
-            drillDownComponentName
-            selection=currentDrilldownStep.selection
-            viewDataStore=viewDataStore
-            dataStore=dataStore
-            select=(action "select")
-            drillDown=(action "drillDown")
-        }}
-    </div>
-{{/if}}
-
 {{#if isViewAsSupported}}
     <div class="wsd-capture-view__settings-bar">
         <label class="wsd-capture-view__settings-bar-label">
@@ -71,5 +49,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 Hex ASCII
             {{/sd-button}}
         </div>
+    </div>
+{{/if}}
+
+{{#if isOverview}}
+    {{wsd-capture-overview
+        filePath=captureInfo.filePath
+        timelines=metricTimelines
+        timeWindow=timeWindow
+        drilldownInfoParam=model.queryParams.drilldownInfoParam
+        toggleMetricTimeline=(action toggleMetricTimeline)
+        drillDown=(action drillDown)
+    }}
+{{else}}
+    <div class="wsd-capture-view__content">
+        {{component
+            drillDownComponentName
+            selection=currentDrilldownStep.selection
+            viewDataStore=viewDataStore
+            dataStore=dataStore
+            select=(action "select")
+            drillDown=(action "drillDown")
+        }}
     </div>
 {{/if}}

--- a/lib/wsd-core/addon/templates/components/wsd-capture-view.hbs
+++ b/lib/wsd-core/addon/templates/components/wsd-capture-view.hbs
@@ -22,21 +22,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div class="wsd-capture-view__settings-bar-control">
             {{#sd-button
                 classNames="sd-button--raised sd-button--no-text-transform sd-button--highlight-on-hover"
-                isActive=isViewAsPrintableAscii
-                size="sm"
-                click=(action "setViewAs" dataStoreConstants.VIEW_AS_PRINTABLE_ASCII)
-            }}
-                Printable ASCII
-            {{/sd-button}}
-        </div>
-        <div class="wsd-capture-view__settings-bar-control">
-            {{#sd-button
-                classNames="sd-button--raised sd-button--no-text-transform sd-button--highlight-on-hover"
                 isActive=isViewAsDottedAscii
                 size="sm"
                 click=(action "setViewAs" dataStoreConstants.VIEW_AS_DOTTED_ASCII)
             }}
                 Dotted ASCII
+            {{/sd-button}}
+        </div>
+        <div class="wsd-capture-view__settings-bar-control">
+            {{#sd-button
+                classNames="sd-button--raised sd-button--no-text-transform sd-button--highlight-on-hover"
+                isActive=isViewAsPrintableAscii
+                size="sm"
+                click=(action "setViewAs" dataStoreConstants.VIEW_AS_PRINTABLE_ASCII)
+            }}
+                Printable ASCII
             {{/sd-button}}
         </div>
         <div class="wsd-capture-view__settings-bar-control">

--- a/lib/wsd-core/addon/templates/components/wsd-capture-view.hbs
+++ b/lib/wsd-core/addon/templates/components/wsd-capture-view.hbs
@@ -37,3 +37,41 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         {{/sd-promise-wait-overlay}}
     </div>
 {{/if}}
+
+{{#if isViewAsSupported}}
+    <div class="wsd-capture-view__settings-bar">
+        <label class="wsd-capture-view__settings-bar-label">
+            <span class="wsd-capture-view__settings-bar-label-text">View As</span>
+        </label>
+        <div class="wsd-capture-view__settings-bar-control">
+            {{#sd-button
+                classNames="sd-button--raised sd-button--no-text-transform sd-button--highlight-on-hover"
+                isActive=isViewAsPrintableAscii
+                size="sm"
+                click=(action "setViewAs" dataStoreConstants.VIEW_AS_PRINTABLE_ASCII)
+            }}
+                Printable ASCII
+            {{/sd-button}}
+        </div>
+        <div class="wsd-capture-view__settings-bar-control">
+            {{#sd-button
+                classNames="sd-button--raised sd-button--no-text-transform sd-button--highlight-on-hover"
+                isActive=isViewAsDottedAscii
+                size="sm"
+                click=(action "setViewAs" dataStoreConstants.VIEW_AS_DOTTED_ASCII)
+            }}
+                Dotted ASCII
+            {{/sd-button}}
+        </div>
+        <div class="wsd-capture-view__settings-bar-control">
+            {{#sd-button
+                classNames="sd-button--raised sd-button--no-text-transform sd-button--highlight-on-hover"
+                isActive=isViewAsHexAscii
+                size="sm"
+                click=(action "setViewAs" dataStoreConstants.VIEW_AS_HEX_ASCII)
+            }}
+                Hex ASCII
+            {{/sd-button}}
+        </div>
+    </div>
+{{/if}}

--- a/lib/wsd-core/addon/templates/components/wsd-view-list.hbs
+++ b/lib/wsd-core/addon/templates/components/wsd-view-list.hbs
@@ -38,7 +38,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             title="I/O streams"
             classNames="sd-button--big sd-button--raised"
             color="white"
-            isSelected=isEchoSelected
+            isActive=isEchoSelected
             click=(action "selectView" "echo")
         }}
             I/O Streams
@@ -50,7 +50,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             title="Syscalls"
             classNames="sd-button--big sd-button--raised"
             color="white"
-            isSelected=isDigSelected
+            isActive=isDigSelected
             click=(action "selectView" "dig")
         }}
             Syscalls


### PR DESCRIPTION
## Todo

- [x] Formatting
- [x] Shortcuts
- [x] Buttons
---
The user can now control how data is formatted on screen

## Dotted ASCII
Keyboard shortcut: <kbd>V</kbd>+<kbd>D</kbd>.

Default option (same as for sysdig and csysdig). 

<img width="776" alt="screenshot 2017-10-15 10 50 36" src="https://user-images.githubusercontent.com/5033993/31587445-d5dcefc2-b196-11e7-9c0f-295109501e37.png">
<img width="776" alt="screenshot 2017-10-15 10 51 00" src="https://user-images.githubusercontent.com/5033993/31587446-d800ebf0-b196-11e7-894e-151217e6ba18.png">


## Printable ASCII
Keyboard shortcut: <kbd>V</kbd>+<kbd>A</kbd>.

Same as `-A` parameter for sysdig: _Only print the text portion of data buffers, and echo end-of-lines. This is useful to only display human-readable data._

<img width="776" alt="screenshot 2017-10-15 10 50 45" src="https://user-images.githubusercontent.com/5033993/31587447-dcb4cc70-b196-11e7-97f3-3ab52011428f.png">
<img width="776" alt="screenshot 2017-10-15 10 51 10" src="https://user-images.githubusercontent.com/5033993/31587448-de1da5dc-b196-11e7-80ea-39828ca57df5.png">


## Hex + ASCII
Keyboard shortcut: <kbd>V</kbd>+<kbd>D</kbd>.

Same as `-X` parameter for sysdig: _Print data buffers in hex and ASCII._

<img width="776" alt="screenshot 2017-10-15 10 50 49" src="https://user-images.githubusercontent.com/5033993/31587449-e229bbb6-b196-11e7-9f2b-b427075dd79e.png">
<img width="776" alt="screenshot 2017-10-15 10 51 19" src="https://user-images.githubusercontent.com/5033993/31587451-e347dcd0-b196-11e7-95ef-d94fda74a43b.png">
