### PR TITLE
Add HTTP header for referer product

### DIFF
--- a/lib/wsd-core/addon/adapters/view.js
+++ b/lib/wsd-core/addon/adapters/view.js
@@ -14,7 +14,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import Ember from 'ember';
 import WsdRESTAdapter from 'wsd-core/adapters/wsdRESTAdapter';
 
 export default WsdRESTAdapter.extend({

--- a/lib/wsd-core/addon/adapters/view.js
+++ b/lib/wsd-core/addon/adapters/view.js
@@ -15,7 +15,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import Ember from 'ember';
-import WsdRESTAdapter from 'wsdRESTAdapter';
+import WsdRESTAdapter from 'wsd-core/adapters/wsdRESTAdapter';
 
 export default WsdRESTAdapter.extend({
     buildURL() {

--- a/lib/wsd-core/addon/adapters/wsdRESTAdapter.js
+++ b/lib/wsd-core/addon/adapters/wsdRESTAdapter.js
@@ -14,11 +14,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+import DS from 'ember-data';
 import Ember from 'ember';
-import WsdRESTAdapter from 'wsdRESTAdapter';
 
-export default WsdRESTAdapter.extend({
-    buildURL() {
-        return this.get('apiServerAdapter').buildURL('/capture/views');
-    },
+export default DS.RESTAdapter.extend({
+    apiServerAdapter: Ember.inject.service('api-server-adapter'),
+    headers: Ember.computed.readOnly('apiServerAdapter.headers'),
 });

--- a/lib/wsd-core/addon/services/api-server-adapter.js
+++ b/lib/wsd-core/addon/services/api-server-adapter.js
@@ -19,6 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import Ember from 'ember';
 
 export default Ember.Service.extend({
+    session: Ember.inject.service('session'),
+
     configTarget: Ember.computed(function() {
         if (window && window.process && window.process.type) {
             return 'ELECTRON';
@@ -51,6 +53,32 @@ export default Ember.Service.extend({
                 return null;
         }
     }).readOnly(),
+
+    headers: Ember.computed('session.refererProduct', function() {
+        switch (this.get('configTarget')) {
+            case 'WEB_SD':
+                return {
+                    'X-Sysdig-Product': this.get('session.refererProduct'),
+                };
+            default:
+                return {};
+        }
+    }).readOnly(),
+
+    init(...args) {
+        this._super(...args);
+
+        if (this.get('configTarget') === 'WEB_SD') {
+            // Set HTTP header to calls through jQuery to identify the referer product (if any)
+            Ember.$.ajaxSetup({
+                dataType: 'json',
+                contentType: 'application/json',
+                beforeSend: (xhr) => {
+                    xhr.setRequestHeader('X-Sysdig-Product', this.get('headers.X-Sysdig-Product'));
+                },
+            });
+        }
+    },
 
     buildURL(url) {
         if (url === '/capture/views') {

--- a/lib/wsd-core/addon/services/fetch-capture-summary.js
+++ b/lib/wsd-core/addon/services/fetch-capture-summary.js
@@ -54,6 +54,7 @@ export default Ember.Service.extend({
                             cacheId,
                             onStartCallback: (p, c) => this.get('cache').store(c, p),
                             url,
+                            headers: this.get('apiServerAdapter.headers'),
                             slowItDown: this.get('slowItDown').createSession(),
                         },
                         300
@@ -70,10 +71,10 @@ function getCacheId(params) {
     return JSON.stringify(params);
 }
 
-function loadData({ resolve, reject, promiseState, cacheId, onStartCallback, url, slowItDown }) {
+function loadData({ resolve, reject, promiseState, cacheId, onStartCallback, url, headers, slowItDown }) {
     onStartCallback(promiseState, cacheId);
 
-    oboe(url)
+    oboe({ url, headers })
         .node('slices.*', (data) => {
             slowItDown.doIt(() => {
                 promiseState.completePartialLoad(data);

--- a/lib/wsd-core/addon/services/fetch-view-data.js
+++ b/lib/wsd-core/addon/services/fetch-view-data.js
@@ -64,6 +64,7 @@ export default Ember.Service.extend({
                             cacheId,
                             onStartCallback: (p, c) => this.get('cache').store(c, p),
                             url,
+                            headers: this.get('apiServerAdapter.headers'),
                             slowItDown: this.get('slowItDown').createSession(),
                         },
                         300
@@ -97,10 +98,10 @@ function serializeViewAs(viewAs) {
     }
 }
 
-function loadData({ resolve, reject, promiseState, cacheId, onStartCallback, url, slowItDown }) {
+function loadData({ resolve, reject, promiseState, cacheId, onStartCallback, url, headers, slowItDown }) {
     onStartCallback(promiseState, cacheId);
 
-    oboe(url)
+    oboe({ url, headers })
         .node('slices.*', (data) => {
             slowItDown.doIt(() => {
                 promiseState.completePartialLoad(data);

--- a/lib/wsd-core/addon/services/session.js
+++ b/lib/wsd-core/addon/services/session.js
@@ -1,0 +1,31 @@
+/*
+Copyright (C) 2017 Draios inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import Ember from 'ember';
+
+export default Ember.Service.extend({
+    hasRefererProductBeenSet: false,
+    refererProduct: null,
+
+    setRefererProductOnce(refererProduct) {
+        if (this.get('hasRefererProductBeenSet') === false) {
+            this.setProperties({
+                refererProduct,
+                hasRefererProductBeenSet: true,
+            });
+        }
+    },
+});

--- a/lib/wsd-core/app/adapters/wsdRESTAdapter.js
+++ b/lib/wsd-core/app/adapters/wsdRESTAdapter.js
@@ -14,11 +14,4 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import Ember from 'ember';
-import WsdRESTAdapter from 'wsdRESTAdapter';
-
-export default WsdRESTAdapter.extend({
-    buildURL() {
-        return this.get('apiServerAdapter').buildURL('/capture/views');
-    },
-});
+export { default } from 'wsd-core/adapters/wsdRESTAdapter';

--- a/lib/wsd-core/app/services/session.js
+++ b/lib/wsd-core/app/services/session.js
@@ -1,0 +1,17 @@
+/*
+Copyright (C) 2017 Draios inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+export { default } from 'wsd-core/services/session';


### PR DESCRIPTION
Set HTTP header `X-Sysdig-Product` when Inspect is launched by Sysdig Monitor or Secure.