### PR TITLE
Fix number of items to parse if the total goes beyond limit

### DIFF
--- a/lib/wsd-core/addon/services/fetch-view-data.js
+++ b/lib/wsd-core/addon/services/fetch-view-data.js
@@ -143,7 +143,7 @@ const BaseDataPromiseState = PromiseState.extend({
     parsePartialData(data) {
         const currentLength = this.get('rows.length');
         const moreLength = Ember.isEmpty(data.data) == false ? data.data.length : 0;
-        const addLength = Math.min(MAX_ROW_COUNT - (currentLength + moreLength), moreLength);
+        const addLength = Math.min(MAX_ROW_COUNT, currentLength + moreLength) - currentLength;
 
         return {
             loadingProgress: data.progress,


### PR DESCRIPTION
Fixes #39. Here the expected result of the use case in the issue:

<img width="1552" alt="screenshot 2018-09-25 14 14 44" src="https://user-images.githubusercontent.com/5033993/46043670-71826600-c0cd-11e8-89af-1e03cfe7e935.png">
