### PR TITLE
fix MacOS reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Where to start?
 
 Here are the installers available for the latest version:
 
-* MAC installer: https://setns.run/install-inspect
+* MacOS installer: https://setns.run/install-inspect
 * Windows installer: https://setns.run/install-inspect-windows
 * Linux installer (RPM version): https://setns.run/install-inspect-rpm
 * Linux installer (DEB version): https://setns.run/install-inspect-deb


### PR DESCRIPTION
Replace the common, yet incorrect, "MAC" capitalizaiton with current name of the operating system.