### PR TITLE
fix(backend): don't fail on stderr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sysdig/sysdig:0.27.1
+FROM sysdig/sysdig:0.36.1
 
 
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-SYSDIG_VERSION="0.35.4"
-SYSDIG_VERSION_MAC="0.35.4"
+SYSDIG_VERSION="0.36.1"
+SYSDIG_VERSION_MAC="0.36.1"
 
 # Env parameters
 # - CLEANUP (default: true)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysdig-inspect",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Sysdig Inspect",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This prevents from failing on non-fatal errors. Furthermore it updates `sysdig` to the latest version available (0.36.1).