### PR TITLE
fix(backend): upgrade fsevents 1.2.9 -> 1.2.11 (MAL-2023-462)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,34 +34,39 @@ jobs:
       BUILDER: "sysdiglabs/sysdig-inspect-builder:0.2"
       SEMVER: ${{ needs.build-settings.outputs.semver }}
       VERSION: ${{ needs.build-settings.outputs.version }}
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     runs-on: ubuntu-latest
-    container:
-      image: "sysdiglabs/sysdig-inspect-builder:0.2"
-      env:
-        INSTALL_DEPS: true
-        GIT_BRANCH: dev
-        SEMVER: ${{ needs.build-settings.outputs.semver }}
-        VERSION: ${{ needs.build-settings.outputs.version }}
-        BUILD_MAC: true
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
     steps:
+      # NOTE: JS actions (checkout, upload-artifact) run on the host runner, not
+      # inside the builder container. The builder image has a glibc too old to
+      # run the runner-injected node20 that those actions require. Only the build
+      # itself runs inside the container, via `docker run` below.
       - name: Checkout Sysdig
-        uses: actions/checkout@v3
-      - name: install 7z
-        run: |
-          cd /tmp
-          sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf &&
-          update-ca-certificates -f &&
-          curl -L -o 7z.tar.xz https://www.7-zip.org/a/7z2301-linux-x64.tar.xz &&
-          tar -xaf 7z.tar.xz &&
-          mv 7zz /usr/bin/7z &&
-          rm -vfr /tmp/* &&
-          cd -
+        uses: actions/checkout@v4
       - name: Build sysdig-inspect
-        run: ./build/build.sh
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/workspace \
+            -w /workspace \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -e INSTALL_DEPS=true \
+            -e GIT_BRANCH=dev \
+            -e SEMVER="${SEMVER}" \
+            -e VERSION="${VERSION}" \
+            -e BUILD_MAC=true \
+            "${BUILDER}" \
+            bash -c '
+              set -e
+              cd /tmp
+              sed -i "/^mozilla\/DST_Root_CA_X3/s/^/!/" /etc/ca-certificates.conf
+              update-ca-certificates -f
+              curl -L -o 7z.tar.xz https://www.7-zip.org/a/7z2301-linux-x64.tar.xz
+              tar -xaf 7z.tar.xz
+              mv 7zz /usr/bin/7z
+              rm -vfr /tmp/*
+              cd /workspace
+              ./build/build.sh
+            '
       - name: Upload artifacts rpm
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,25 +63,25 @@ jobs:
       - name: Build sysdig-inspect
         run: ./build/build.sh
       - name: Upload artifacts rpm
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sysdig-inspect-${{ env.VERSION }}-linux-x86_64.rpm
           path: |
             out/linux/installers/sysdig-inspect-linux-x86_64.rpm
       - name: Upload artifacts deb
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sysdig-inspect-${{ env.VERSION }}-linux-x86_64.deb
           path: |
             out/linux/installers/sysdig-inspect-linux-x86_64.deb
       - name: Upload artifacts dmg
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sysdig-inspect-${{ env.VERSION }}-mac-x86_64.dmg
           path: |
             out/mac/binaries/sysdig-inspect-${{ env.SEMVER }}-mac-86_64.dmg
       - name: Upload artifacts zip
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sysdig-inspect-${{ env.VERSION }}-mac-x86_64.zip
           path: |

--- a/ember-electron/backend/package-lock.json
+++ b/ember-electron/backend/package-lock.json
@@ -1188,13 +1188,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -1230,6 +1231,15 @@
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "optional": true
+        },
+        "bindings": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "optional": true,
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -1296,6 +1306,12 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+          "optional": true
+        },
+        "file-uri-to-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
           "optional": true
         },
         "fs-minipass": {


### PR DESCRIPTION
fsevents@1.2.9 contains malicious code (MAL-2023-462). Upgrade the transitive/optional dependency to the safe 1.2.11, adding the new bindings@1.5.0 and file-uri-to-path@1.0.0 sub-dependencies to the lockfile.