### PR TITLE
release: bump version to 0.12.1 and fix release workflow

### DIFF
--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -13,53 +13,58 @@ jobs:
     env:
       BUILDER: "sysdiglabs/sysdig-inspect-builder:0.2"
       VERSION: ${{ github.ref_name }}
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     runs-on: ubuntu-latest
-    container:
-      image: "sysdiglabs/sysdig-inspect-builder:0.2"
-      env:
-        INSTALL_DEPS: true
-        GIT_BRANCH: ${{ github.ref_name }}
-        VERSION: ${{ github.ref_name }}
-        BUILD_MAC: true
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
     steps:
+      # NOTE: JS actions (checkout, upload-artifact) run on the host runner, not
+      # inside the builder container. The builder image has a glibc too old to
+      # run the runner-injected node20 that those actions require. Only the build
+      # itself runs inside the container, via `docker run` below.
       - name: Checkout Sysdig
-        uses: actions/checkout@v3
-      - name: install 7z
-        run: |
-          cd /tmp
-          sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf &&
-          update-ca-certificates -f &&
-          curl -L -o 7z.tar.xz https://www.7-zip.org/a/7z2301-linux-x64.tar.xz &&
-          tar -xaf 7z.tar.xz &&
-          mv 7zz /usr/bin/7z &&
-          rm -vfr /tmp/* &&
-          cd -
+        uses: actions/checkout@v4
       - name: Build sysdig-inspect
-        run: ./build/build.sh
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/workspace \
+            -w /workspace \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -e INSTALL_DEPS=true \
+            -e GIT_BRANCH="${VERSION}" \
+            -e VERSION="${VERSION}" \
+            -e BUILD_MAC=true \
+            "${BUILDER}" \
+            bash -c '
+              set -e
+              cd /tmp
+              sed -i "/^mozilla\/DST_Root_CA_X3/s/^/!/" /etc/ca-certificates.conf
+              update-ca-certificates -f
+              curl -L -o 7z.tar.xz https://www.7-zip.org/a/7z2301-linux-x64.tar.xz
+              tar -xaf 7z.tar.xz
+              mv 7zz /usr/bin/7z
+              rm -vfr /tmp/*
+              cd /workspace
+              ./build/build.sh
+            '
       - name: Upload artifacts rpm
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sysdig-inspect-release-${{ env.VERSION }}-linux-x86_64.rpm
           path: |
             out/linux/installers/sysdig-inspect-linux-x86_64.rpm
       - name: Upload artifacts deb
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sysdig-inspect-release-${{ env.VERSION }}-linux-x86_64.deb
           path: |
             out/linux/installers/sysdig-inspect-linux-x86_64.deb
       - name: Upload artifacts dmg
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sysdig-inspect-release-${{ env.VERSION }}-mac-x86_64.dmg
           path: |
             out/mac/binaries/sysdig-inspect-${{ env.VERSION }}-mac-x86_64.dmg
       - name: Upload artifacts zip
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sysdig-inspect-release-${{ env.VERSION }}-mac-x86_64.zip
           path: |
@@ -73,15 +78,15 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Download artifacts (linux-amd64 deb)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sysdig-inspect-release-${{ env.VERSION }}-linux-x86_64.deb
       - name: Download artifacts (linux-amd64 rpm)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sysdig-inspect-release-${{ env.VERSION }}-linux-x86_64.rpm
       - name: Download artifacts (osx-amd64)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sysdig-inspect-release-${{ env.VERSION }}-mac-x86_64.zip
       - name: test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysdig-inspect",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Sysdig Inspect",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cuts a **0.12.1** patch release carrying the fsevents `MAL-2023-462` fix (merged in #200).

## Changes
- Bump root `package.json` version `0.12.0` → `0.12.1`.
- Fix `release-draft.yaml` so the tag-triggered release build works (it had the same two defects that were breaking CI):
  - `upload/download-artifact@v3` → `@v4` (GitHub auto-fails jobs using v3).
  - Run JS actions (checkout, upload-artifact) on the host runner and invoke `./build/build.sh` inside the builder container via `docker run` — the container's glibc is too old for the node20 those actions require.

## Release steps (after merge)
Push tag `0.12.1`, which triggers `release-draft.yaml` to build artifacts and create a **draft** GitHub release.